### PR TITLE
chore: go mod tidy after update

### DIFF
--- a/default.json
+++ b/default.json
@@ -7,7 +7,7 @@
   "rebaseWhen": "conflicted",
   "schedule": "on Wednesdays",
   "prHourlyLimit": 2,
-  "postUpdateOptions": ["gomodUpdateImportPaths, gomodTidy"],
+  "postUpdateOptions": ["gomodUpdateImportPaths", "gomodTidy"],
   "packageRules": [
     {
       "groupName": "js minor and patch",
@@ -19,7 +19,6 @@
       "groupName": "go minor and patch",
       "matchCategories": ["golang"],
       "matchUpdateTypes": ["digest", "patch", "minor"],
-      "postUpdateOptions": ["gomodTidy"],
       "minimumReleaseAge": "3 days"
     },
     {

--- a/default.json
+++ b/default.json
@@ -19,6 +19,7 @@
       "groupName": "go minor and patch",
       "matchCategories": ["golang"],
       "matchUpdateTypes": ["digest", "patch", "minor"],
+      "postUpdateOptions": ["gomodTidy"],
       "minimumReleaseAge": "3 days"
     },
     {


### PR DESCRIPTION
Renovate should tidy the `go.mod` and `go.sum` files in its update PRs.